### PR TITLE
Refactor: Restrict app to web and tablet devices

### DIFF
--- a/lib/web.dart
+++ b/lib/web.dart
@@ -1,9 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mishads_codefolio/core/config/web_theme.dart';
+import 'package:mishads_codefolio/core/utils/smooth_scroll_behavior.dart';
 import 'package:mishads_codefolio/feature/home/view/home_view.dart';
 import 'package:responsive_sizer/responsive_sizer.dart';
-
-import 'core/utils/smooth_scroll_behavior.dart';
 
 class Web extends StatelessWidget {
   const Web({super.key});
@@ -12,13 +12,28 @@ class Web extends StatelessWidget {
   Widget build(BuildContext context) {
     return ResponsiveSizer(
       builder: (context, orientation, screenType) {
-        return MaterialApp(
-          title: 'Flutter Demo',
-          theme: WebTheme.lightTheme,
-          scrollBehavior: SmoothScrollBehavior(),
-          darkTheme: WebTheme.darkTheme,
-          home: HomeView(),
-        );
+        if (kIsWeb ||
+            screenType == ScreenType.tablet ||
+            screenType == ScreenType.desktop) {
+          return MaterialApp(
+            title: 'Flutter Web App',
+            theme: WebTheme.lightTheme,
+            darkTheme: WebTheme.darkTheme,
+            scrollBehavior: SmoothScrollBehavior(),
+            home: const HomeView(),
+          );
+        } else {
+          return const MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: Text(
+                  'This app is only available on web or tablet devices.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          );
+        }
       },
     );
   }


### PR DESCRIPTION
This commit modifies the `Web` widget to conditionally render content based on the platform and screen type.

- If the app is running on the web (`kIsWeb`) or the screen type is tablet or desktop, the original `MaterialApp` with `HomeView` is displayed.
- Otherwise (likely on mobile devices), a simple `MaterialApp` with a `Scaffold` is shown, displaying a message indicating that the app is only available on web or tablet devices.

The import for `SmoothScrollBehavior` was also moved.