### PR TITLE
Refactor: Update image loading in ProjectCard and adjust StoryView he…

### DIFF
--- a/lib/feature/projects/widgets/project_card.dart
+++ b/lib/feature/projects/widgets/project_card.dart
@@ -108,20 +108,9 @@ class ProjectCard extends StatelessWidget {
                   child: SizedBox(
                     height: 200,
                     width: 500,
-                    child: Image.network(
+                    child: Image.asset(
                       project.imageUrl!,
                       fit: BoxFit.contain,
-                      loadingBuilder: (context, child, loadingProgress) {
-                        if (loadingProgress == null) return child;
-                        return Center(
-                          child: CircularProgressIndicator(
-                            value: loadingProgress.expectedTotalBytes != null
-                                ? loadingProgress.cumulativeBytesLoaded /
-                                      (loadingProgress.expectedTotalBytes!)
-                                : null,
-                          ),
-                        );
-                      },
                       errorBuilder: (context, error, stackTrace) =>
                           const Icon(Icons.broken_image, size: 60),
                     ),

--- a/lib/feature/story/view/story_view.dart
+++ b/lib/feature/story/view/story_view.dart
@@ -18,7 +18,8 @@ class _StoryViewState extends State<StoryView> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           SizedBox(
-            height: ScreenSize.scaleHeight(context, 500),
+            height: ScreenSize.scaleHeight(context, 600),
+
             child: Center(
               child: WebText("Will be adding soon", color: Colors.white),
             ),


### PR DESCRIPTION
…ight

This commit makes the following changes:

- **ProjectCard:**
    - Changed `Image.network` to `Image.asset` for loading project images.
    - Removed the `loadingBuilder` as it's not applicable to `Image.asset`.
- **StoryView:**
    - Increased the height of the `SizedBox` from 500 to 600 using `ScreenSize.scaleHeight`.