### PR TITLE
Refactor: Update UI elements and content

### DIFF
--- a/lib/data/technologies_data.dart
+++ b/lib/data/technologies_data.dart
@@ -6,13 +6,6 @@ import '../core/config/web_icons.dart';
 class TechnologiesData extends ChangeNotifier {
   final List<SkillCategory> _codingSkills = [
     SkillCategory(
-      title: 'Publication in Both Stores',
-      items: [
-        SkillItemModel(name: 'App Store', iconPath: WebIcons.ios),
-        SkillItemModel(name: 'Play Store', iconPath: WebIcons.googlePlay),
-      ],
-    ),
-    SkillCategory(
       title: 'Programming Languages',
       items: [
         SkillItemModel(name: 'C++', iconPath: WebIcons.cplus),
@@ -74,6 +67,13 @@ class TechnologiesData extends ChangeNotifier {
         SkillItemModel(name: 'Riverpod', iconPath: WebIcons.flutter),
         SkillItemModel(name: 'BLoC', iconPath: WebIcons.flutter),
         SkillItemModel(name: 'GetX', iconPath: WebIcons.flutter),
+      ],
+    ),
+    SkillCategory(
+      title: 'Publication in ',
+      items: [
+        //SkillItemModel(name: 'App Store', iconPath: WebIcons.ios),
+        SkillItemModel(name: 'Play Store', iconPath: WebIcons.googlePlay),
       ],
     ),
   ];

--- a/lib/feature/home/view/home_view.dart
+++ b/lib/feature/home/view/home_view.dart
@@ -56,7 +56,6 @@ class _HomeViewState extends State<HomeView>
                     stackSlider(model),
                     SizedBox(height: 10.h),
                     MyExpertiseView(),
-                    SizedBox(height: 10.h),
                     AboutTechnologies(),
                   ],
                 ),

--- a/lib/feature/home/view/widget/about_technologies.dart
+++ b/lib/feature/home/view/widget/about_technologies.dart
@@ -53,7 +53,7 @@ class _AboutTechnologiesState extends State<AboutTechnologies> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           return Wrap(
-            spacing: 5.w,
+            spacing: 6.w,
             runSpacing: 16,
             children: technologies.map((category) {
               return Material(
@@ -96,6 +96,7 @@ class _AboutTechnologiesState extends State<AboutTechnologies> {
                                   skill.iconPath,
                                   height: 4.h,
                                   width: 4.w,
+                                  fit: BoxFit.contain,
                                 ),
                                 SizedBox(width: 2.w),
                                 Expanded(

--- a/lib/feature/home/view/widget/my_expertise_view.dart
+++ b/lib/feature/home/view/widget/my_expertise_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:mishads_codefolio/core/config/web_icons.dart';
 import 'package:mishads_codefolio/core/utils/web_custom_text.dart';
 import 'package:responsive_sizer/responsive_sizer.dart';
@@ -35,7 +36,7 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
       "languages":
           "Python, NumPy, Pandas, TensorFlow, Keras, CNN, ANN, OpenCV, Scikit-learn",
       "details":
-          "Experienced in machine learning and deep learning with hands-on projects involving artificial neural networks (ANN) and convolutional neural networks (CNN). Proficient in data preprocessing and manipulation using NumPy and Pandas. Skilled in developing and training models using TensorFlow and Keras. Knowledgeable in computer vision techniques using OpenCV and image classification tasks. Familiar with Scikit-learn for traditional ML algorithms and evaluation.",
+          "Experienced in machine learning and deep learning with hands-on projects involving artificial neural networks (ANN), convolutional neural networks (CNN) and Recurrent Neural Network (RNN). Proficient in data preprocessing and manipulation using NumPy and Pandas. Skilled in developing and training models using TensorFlow and Keras. Knowledgeable in computer vision techniques using OpenCV and image classification tasks. Familiar with Scikit-learn for traditional ML algorithms and evaluation.",
     },
   ];
 
@@ -48,7 +49,7 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
           textAlign: TextAlign.center,
           text: TextSpan(
             text: "MY ",
-            style: TextStyle(
+            style: GoogleFonts.raleway(
               fontWeight: FontWeight.w400,
               fontSize: 4.2.w,
               color: Colors.white,
@@ -56,7 +57,7 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
             children: [
               TextSpan(
                 text: "EXPERTISE",
-                style: TextStyle(
+                style: GoogleFonts.raleway(
                   fontWeight: FontWeight.w400,
                   fontSize: 4.2.w,
                   color: WebColors.primary,
@@ -66,7 +67,7 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
           ),
         ),
         WebText(
-          "What can I do",
+          "What I can do",
           fontSize: 14.sp,
           fontWeight: FontWeight.w300,
           color: Colors.white,
@@ -78,11 +79,11 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
           alignment: WrapAlignment.center,
           children: expertise.map((item) {
             return Container(
-              height: 55.h,
+              height: 50.h,
               width: 30.w,
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(30),
-                color: Colors.black.withOpacity(0.7),
+                color: WebColors.gray700,
               ),
               padding: EdgeInsets.symmetric(horizontal: 2.w, vertical: 1.5.h),
               child: Column(
@@ -137,9 +138,9 @@ class _MyExpertiseViewState extends State<MyExpertiseView> {
                       fontSize: 12.sp,
                       fontWeight: FontWeight.w300,
                       color: Colors.white,
-
                       overflow: TextOverflow.ellipsis,
-                      maxLines: 5,
+                      textAlign: TextAlign.center,
+                      maxLines: 7,
                     ),
                   ),
                 ],

--- a/lib/feature/home/view/widget/stack_slider.dart
+++ b/lib/feature/home/view/widget/stack_slider.dart
@@ -12,61 +12,20 @@ import '../../view_model/stack_slide.dart';
 
 class StackSlider extends StatelessWidget {
   final List<Map<String, dynamic>> stackItems = [
-    {
-      'name': 'Flutter',
-      'color': Color(0xFF02569B), // Official Flutter Blue
-      'image': WebIcons.flutter,
-    },
-    {
-      'name': 'Kotlin',
-      'color': Color(0xFF7F52FF), // Official Kotlin Purple
-      'image': WebIcons.kotlin,
-    },
-
-    {
-      'name': 'Dart',
-      'color': Color(0xFF0175C2), // Official Dart Blue
-      'image': WebIcons.dart,
-    },
-    {
-      'name': 'C++',
-      'color': Color(0xFF00599C), // Commonly accepted C++ Blue
-      'image': WebIcons.cplus,
-    },
-    {
-      'name': 'Java',
-      'color': Color(0xFF005082), // Deeper, richer Java Blue
-      'image': WebIcons.java,
-    },
-
-    {
-      'name': 'Python',
-      'color': Color(0xFF3776AB), // Official Python Blue
-      'image': WebIcons.python,
-    },
+    {'name': 'Flutter', 'color': Color(0xFF02569B), 'image': WebIcons.flutter},
+    {'name': 'Kotlin', 'color': Color(0xFF7F52FF), 'image': WebIcons.kotlin},
+    {'name': 'Dart', 'color': Color(0xFF0175C2), 'image': WebIcons.dart},
+    {'name': 'C++', 'color': Color(0xFF00599C), 'image': WebIcons.cplus},
+    {'name': 'Java', 'color': Color(0xFF005082), 'image': WebIcons.java},
+    {'name': 'Python', 'color': Color(0xFF3776AB), 'image': WebIcons.python},
     {
       'name': 'Firebase',
-      'color': Color(0xFFDD6C00), // Darker orange for Firebase (good contrast)
+      'color': Color(0xFFDD6C00),
       'image': WebIcons.firebase,
     },
-
-    /*{
-      'name': 'Git',
-      'color': Color(0xFF9A2500), // Dark reddish-orange for Git
-      'image': WebIcons.git,
-    },*/
-    {
-      'name': 'GitHub',
-      'color': Color(0xFF636363), // Official GitHub Black
-      'image': WebIcons.github,
-    },
-    {
-      'name': 'SQLite',
-      'color': Color(0xFF003B57), // Official SQLite Blue
-      'image': WebIcons.sqlite,
-    },
+    {'name': 'GitHub', 'color': Color(0xFF636363), 'image': WebIcons.github},
+    {'name': 'SQLite', 'color': Color(0xFF003B57), 'image': WebIcons.sqlite},
   ];
-
   StackSlider({super.key});
 
   @override
@@ -87,7 +46,7 @@ class StackSlider extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 WebText(
-                  "3 years of",
+                  "2 years of",
                   color: WebColors.gray400,
                   fontSize: 16.sp,
                 ),
@@ -151,10 +110,11 @@ class StackSlider extends StatelessWidget {
                                       item['image'],
                                       placeholderBuilder: (context) =>
                                           const CircularProgressIndicator(),
-                                      width: 50, // Try hardcoding size
-                                      height: 50,
+                                      width: 6.w,
+                                      height: 6.h,
                                       fit: BoxFit.contain,
                                     ),
+                                    SizedBox(height: 1.h),
                                     WebText(
                                       item['name'],
                                       color: Colors.white,

--- a/lib/feature/story/view/story_view.dart
+++ b/lib/feature/story/view/story_view.dart
@@ -21,7 +21,7 @@ class _StoryViewState extends State<StoryView> {
             height: ScreenSize.scaleHeight(context, 600),
 
             child: Center(
-              child: WebText("Will be adding soon", color: Colors.white),
+              child: WebText("Will be adding soon...", color: Colors.white),
             ),
           ),
         ],


### PR DESCRIPTION
Refactor: Update UI elements and content

This commit includes several UI refinements and content updates across the application:

**Home View & Widgets:**
- `AboutTechnologies`:
    - Adjusted spacing between technology items.
    - Set `fit: BoxFit.contain` for skill icons.
- `MyExpertiseView`:
    - Changed "What can I do" to "What I can do".
    - Updated ML/DL expertise details to include Recurrent Neural Network (RNN).
    - Modified title font to `Raleway`.
    - Adjusted container height and background color for expertise items.
    - Increased `maxLines` for details text and centered it.
- `StackSlider`:
    - Changed "3 years of" to "2 years of" experience.
    - Adjusted image size and added spacing below images in the stack slider.
    - Removed 'Git' from the displayed stack items.
- `HomeView`:
    - Removed an empty `SizedBox` between `MyExpertiseView` and `AboutTechnologies`.

**Data:**
- `TechnologiesData`:
    - Moved 'Publication in' category to the end of the list.
    - Commented out 'App Store' from 'Publication in' category.

**Story View:**
- Updated placeholder text to "Will be adding soon...".